### PR TITLE
fix-issues-222-223-224

### DIFF
--- a/src/Application/Masa.Alert.Application/AlarmHistories/Queries/AlarmHistoryQueryHandler.cs
+++ b/src/Application/Masa.Alert.Application/AlarmHistories/Queries/AlarmHistoryQueryHandler.cs
@@ -35,10 +35,11 @@ public class AlarmHistoryQueryHandler
     [EventHandler]
     public async Task GetListAsync(GetAlarmHistoryListQuery query)
     {
+        using var dataFilter = _dataFilter.Disable<ISoftDelete>();
         var options = query.Input;
         var condition = await CreateFilteredPredicate(options);
         var sorting = options.ApplySorting();
-        var resultList = await _context.AlarmHistoryQueries.Include(x => x.AlarmRule).GetPaginatedListAsync(condition, new()
+        var resultList = await _context.AlarmHistoryQueries.Include(x => x.AlarmRule).Where(x => !x.IsDeleted).GetPaginatedListAsync(condition, new()
         {
             Page = options.Page,
             PageSize = options.PageSize,

--- a/src/Domain/Masa.Alert.Domain.Shared/AlarmRules/AlarmRuleChannelTypes.cs
+++ b/src/Domain/Masa.Alert.Domain.Shared/AlarmRules/AlarmRuleChannelTypes.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Alert.Domain.Shared.AlarmRules
+{
+    public enum AlarmRuleChannelTypes
+    {
+        Sms = 1,
+        Email,
+        WebsiteMessage
+    }
+}

--- a/src/Web/Masa.Alert.Web.Admin/Components/Modules/Notification/NotificationConfig.razor
+++ b/src/Web/Masa.Alert.Web.Admin/Components/Modules/Notification/NotificationConfig.razor
@@ -20,11 +20,11 @@
     <MRow Class="mt-0">
         <MCol>
             <SSelect @bind-Value="@Value.ChannelType"
-                     Items="Enum.GetValues<ChannelTypes>().ToList()"
+                     Items="Enum.GetValues<AlarmRuleChannelTypes>().ToList()"
                      Label="@T("ChannelType")"
                      ItemText="item => T(item.ToString())"
                      ItemValue="item => (int)item"
-                     TItem="ChannelTypes"
+                     TItem="AlarmRuleChannelTypes"
                      TItemValue="int"
                      TValue="int"
                      OnSelectedItemUpdate="HandleChannelTypeChangeAsync">

--- a/src/Web/Masa.Alert.Web.Admin/Pages/AlarmHistory/AlarmHistoryManagement.razor
+++ b/src/Web/Masa.Alert.Web.Admin/Pages/AlarmHistory/AlarmHistoryManagement.razor
@@ -91,7 +91,7 @@
     </HeaderContent>
     <AutoHeightContent>
         <MCard Class="@(!advanced?"page-content mt-6":"page-content-advanced mt-6")">
-            <SDataTable Headers="_headers" Items="_entities.Result" TItem="AlarmHistoryListViewModel" ItemsPerPage="_queryParam.PageSize" OnOptionsUpdate="HandleOnOptionsUpdate" HideDefaultFooter Class="d-flex full-height flex-column">
+            <SDataTable Headers="_headers" Items="_entities.Result" TItem="AlarmHistoryListViewModel" ItemsPerPage="_queryParam.PageSize" OnOptionsUpdate="HandleOnOptionsUpdate" HideDefaultFooter @ref="_dataTableRef" Class="d-flex full-height flex-column">
                 <HeaderColContent Context="header">
                     <span class="text-btn">@header.Text</span>
                 </HeaderColContent>

--- a/src/Web/Masa.Alert.Web.Admin/Pages/AlarmHistory/AlarmHistoryManagement.razor.cs
+++ b/src/Web/Masa.Alert.Web.Admin/Pages/AlarmHistory/AlarmHistoryManagement.razor.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
-using Force.DeepCloner;
-
 namespace Masa.Alert.Web.Admin.Pages.AlarmHistory;
 
 public partial class AlarmHistoryManagement : AdminCompontentBase

--- a/src/Web/Masa.Alert.Web.Admin/Pages/AlarmHistory/AlarmHistoryManagement.razor.cs
+++ b/src/Web/Masa.Alert.Web.Admin/Pages/AlarmHistory/AlarmHistoryManagement.razor.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
+using Force.DeepCloner;
+
 namespace Masa.Alert.Web.Admin.Pages.AlarmHistory;
 
 public partial class AlarmHistoryManagement : AdminCompontentBase
@@ -22,6 +24,8 @@ public partial class AlarmHistoryManagement : AdminCompontentBase
     AlarmRuleService AlarmRuleService => AlertCaller.AlarmRuleService;
 
     protected override string? PageName { get; set; } = "AlarmHistoryBlock";
+
+    private SDataTable<AlarmHistoryListViewModel> _dataTableRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -142,26 +146,28 @@ public partial class AlarmHistoryManagement : AdminCompontentBase
     private async Task HandleSearchTypeChange()
     {
         _queryParam = new() { Filter = _queryParam.Filter, SearchType = _queryParam.SearchType, AlarmRuleId = _queryParam.AlarmRuleId, Page = 1 };
-
         switch (_queryParam.SearchType)
         {
             case AlarmHistorySearchTypes.Alarming:
                 _timeTypeItems = Enum.GetValues<AlarmHistorySearchTimeTypes>().Where(x => x != AlarmHistorySearchTimeTypes.ProcessingCompletedTime).ToList();
                 _handleStatusItems = new List<AlarmHistoryHandleStatuses> { AlarmHistoryHandleStatuses.Pending, AlarmHistoryHandleStatuses.InProcess };
                 _queryParam.TimeType = default;
-                _queryParam.Sorting = $"{nameof(AlarmHistoryQueryModel.AlertSeverity)} asc,{nameof(AlarmHistoryQueryModel.FirstAlarmTime)} asc";
+
+                HandleSort(nameof(AlarmHistoryQueryModel.AlertSeverity));
                 break;
             case AlarmHistorySearchTypes.Processed:
                 _timeTypeItems = Enum.GetValues<AlarmHistorySearchTimeTypes>().ToList();
                 _handleStatusItems = Enum.GetValues<AlarmHistoryHandleStatuses>().ToList();
                 _queryParam.TimeType = AlarmHistorySearchTimeTypes.ProcessingCompletedTime;
-                _queryParam.Sorting = $"{nameof(AlarmHistoryQueryModel.RecoveryTime)} desc";
+
+                HandleSort(nameof(AlarmHistoryQueryModel.RecoveryTime), true);
                 break;
             case AlarmHistorySearchTypes.NoNotice:
                 _timeTypeItems = Enum.GetValues<AlarmHistorySearchTimeTypes>().Where(x => x != AlarmHistorySearchTimeTypes.ProcessingCompletedTime).ToList();
                 _handleStatusItems = Enum.GetValues<AlarmHistoryHandleStatuses>().ToList();
                 _queryParam.TimeType = default;
-                _queryParam.Sorting = $"{nameof(AlarmHistoryQueryModel.LastAlarmTime)} desc";
+
+                HandleSort(nameof(AlarmHistoryQueryModel.LastAlarmTime), true);
                 break;
             default:
                 break;
@@ -169,6 +175,18 @@ public partial class AlarmHistoryManagement : AdminCompontentBase
 
         await RefreshAsync();
     }
+
+    private void HandleSort(string sortField, bool isDesc = false)
+    {
+        _queryParam.Sorting = $"{sortField} {(isDesc ? "desc" : "")}";
+        _dataTableRef.UpdateOptions(options =>
+        {
+            var sortBys = new List<string> { sortField };
+            _dataTableRef.SortArray(sortBys);
+        });
+    }
+
+
 
     private async Task HandleFilterKeyDown()
     {


### PR DESCRIPTION
fix-issues-222:alert rule, select message template, channel type filter out APP option
fix-issues-223:After an alarm rule is deleted, the name of the corresponding rule is missing in the alarm history
fix-issues-224:Toggle the tab. The order of the table headers is not reset