### PR TITLE
refactor: Improve filter case sensitivity in query handlers

### DIFF
--- a/src/Application/Masa.Alert.Application/AlarmHistories/Queries/AlarmHistoryQueryHandler.cs
+++ b/src/Application/Masa.Alert.Application/AlarmHistories/Queries/AlarmHistoryQueryHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Alert.Application.AlarmHistories.Queries;
@@ -55,7 +55,7 @@ public class AlarmHistoryQueryHandler
     private async Task<Expression<Func<AlarmHistoryQueryModel, bool>>> CreateFilteredPredicate(GetAlarmHistoryInputDto options)
     {
         Expression<Func<AlarmHistoryQueryModel, bool>> condition = x => true;
-        condition = condition.And(!string.IsNullOrEmpty(options.Filter), x => x.AlarmRule.DisplayName.Contains(options.Filter));
+        condition = condition.And(!string.IsNullOrEmpty(options.Filter), x => x.AlarmRule.DisplayName.ToLower().Contains(options.Filter.ToLower()));
         switch (options.SearchType)
         {
             case AlarmHistorySearchTypes.Alarming:

--- a/src/Application/Masa.Alert.Application/AlarmRules/Queries/AlarmRuleQueryHandler.cs
+++ b/src/Application/Masa.Alert.Application/AlarmRules/Queries/AlarmRuleQueryHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Alert.Application.AlarmRules.Queries;
@@ -54,7 +54,7 @@ public class AlarmRuleQueryHandler
     private async Task<Expression<Func<AlarmRuleQueryModel, bool>>> CreateFilteredPredicate(GetAlarmRuleInputDto options)
     {
         Expression<Func<AlarmRuleQueryModel, bool>> condition = x => true;
-        condition = condition.And(!string.IsNullOrEmpty(options.Filter), x => x.DisplayName.Contains(options.Filter));
+        condition = condition.And(!string.IsNullOrEmpty(options.Filter), x => x.DisplayName.ToLower().Contains(options.Filter.ToLower()));
         condition = condition.And(options.Type != default, x => x.Type == options.Type);
         condition = condition.And(x => x.Show == options.Show);
         if (options.TimeType == AlarmRuleSearchTimeTypes.ModificationTime)

--- a/src/Application/Masa.Alert.Application/WebHooks/Queries/WebHookQueryHandler.cs
+++ b/src/Application/Masa.Alert.Application/WebHooks/Queries/WebHookQueryHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Alert.Application.WebHooks.Queries;
@@ -48,7 +48,7 @@ public class WebHookQueryHandler
     private async Task<Expression<Func<WebHookQueryModel, bool>>> CreateFilteredPredicate(GetWebHookInputDto options)
     {
         Expression<Func<WebHookQueryModel, bool>> condition = x => true;
-        condition = condition.And(!string.IsNullOrEmpty(options.Filter), x => x.DisplayName.Contains(options.Filter));
+        condition = condition.And(!string.IsNullOrEmpty(options.Filter), x => x.DisplayName.ToLower().Contains(options.Filter.ToLower()));
         return await Task.FromResult(condition); ;
     }
 


### PR DESCRIPTION
Updated the filtering logic in AlarmHistoryQueryHandler, AlarmRuleQueryHandler, and WebHookQueryHandler to perform case-insensitive searches by converting both the filter and the target display names to lowercase. This enhancement ensures more accurate search results regardless of the case used in the input.